### PR TITLE
Entity: Fixed logic error in getBlocksAround() which caused yet anoth…

### DIFF
--- a/src/pocketmine/entity/Entity.php
+++ b/src/pocketmine/entity/Entity.php
@@ -1665,9 +1665,9 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 			$minX = Math::floorFloat($this->boundingBox->minX + $inset);
 			$minY = Math::floorFloat($this->boundingBox->minY + $inset);
 			$minZ = Math::floorFloat($this->boundingBox->minZ + $inset);
-			$maxX = Math::ceilFloat($this->boundingBox->maxX - $inset);
-			$maxY = Math::ceilFloat($this->boundingBox->maxY - $inset);
-			$maxZ = Math::ceilFloat($this->boundingBox->maxZ - $inset);
+			$maxX = Math::floorFloat($this->boundingBox->maxX - $inset);
+			$maxY = Math::floorFloat($this->boundingBox->maxY - $inset);
+			$maxZ = Math::floorFloat($this->boundingBox->maxZ - $inset);
 
 			$this->blocksAround = [];
 


### PR DESCRIPTION
…er firebug

Try setting a fire at z = -204, then stand on the edge between -205 and -206.

The coordinates that a BB's corners are encapsulated in are always the floor()ed coordinates

If you stand at -205.0, your BB min is -205.3 and your BB max is -204.7, which then incorrectly tells you that the BB intersects with block -204
because ceil(-204.7) == -204
when you actually are only intersecting with -205 and -206
this is as bad as using (int) to floor integers :kms:

## Introduction
<!-- Explain existing problems or why this pull request is necessary -->

### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
